### PR TITLE
Filter :block/path-refs instead of :block/refs

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -46,7 +46,7 @@ function buildCond(cond, i) {
   if (cond.length <= 1) return ""
   if (cond.startsWith("#")) {
     const name = cond.substring(1).toLowerCase()
-    return `[?t${i} :block/name "${name}"] [?b :block/refs ?t${i}]`
+    return `[?t${i} :block/name "${name}"] [?b :block/path-refs ?t${i}]`
   } else if (cond.startsWith("@")) {
     const [name, value] = cond
       .substring(1)


### PR DESCRIPTION
By using path-refs we also filter on refs in parents. Example:
```
- #questions
   - How does X work?
   - What does X do?
```
Query: "#questions" will return both children, which is more useful I think.